### PR TITLE
Replace result '0' when checking for card permissions with a message …

### DIFF
--- a/application/controllers/api.php
+++ b/application/controllers/api.php
@@ -113,10 +113,10 @@ class Api extends CI_Controller {
             Returns 1, as this is a NORMAL user card:
                 curl http://babbage:1234/1/card/AAAAAAAA
             
-            Returns 0, as this is an un-authorised card (assuming you haven't authorised it in testing)
+            Returns REGISTERED, as this is an un-authorised card (assuming you haven't authorised it in testing)
                 curl http://babbage:1234/1/card/BABABABA
 
-            Returns 0, as this is an unknown card
+            Returns UNKNOWN, as this is an unknown card
                 curl http://babbage:1234/1/card/JKLMNOP
     */
     public function card() {
@@ -128,7 +128,13 @@ class Api extends CI_Controller {
         // If we've correctly been presented with a node and a card, then check to see what
         // permission is associated with it
         if (isset($acnode_id) && isset($card_unique_identifier)) {
-            $result = $this->Card_model->get_permission($acnode_id, $card_unique_identifier);
+	    $result = $this->Card_model->get_card_status($card_unique_identifier);
+	    if ($result == 'REGISTERED') {
+	       $permission = $this->Card_model->get_permission($acnode_id, $card_unique_identifier);
+	       if ($permission > 0) {
+	       	  $result = $permission;
+	       }
+	    }       
         } else {
             error_log("Cannot parse query string to determine the Node ($acnode_id) and Card ($card_unique_identifier) values to check");
         }

--- a/application/models/card_model.php
+++ b/application/models/card_model.php
@@ -124,5 +124,19 @@
             }
         }
 
+        /* Check if this card is registered to a user in the system */
+        public function get_card_status($card_unique_identifier) {
+            $this->db->select('card_id');
+            $this->db->from('cards');
+            $this->db->where('cards.card_unique_identifier', $card_unique_identifier);
+            $this->db->where('cards.user_id IS NOT NULL');
+            $query = $this->db->get();
+
+            if ($query->num_rows() == 0) {
+                return 'UNKNOWN';
+            } else {
+                return 'REGISTERED';
+            }
+        }
     }
 ?>


### PR DESCRIPTION
Don't merge yet, I'm looking for feedback.

The idea behind this change is to enable two new scenarios for acnode:

1) to be used as a doorbot replacement
2) to be used in audit-only mode (where any valid card permits you to use a tool).
